### PR TITLE
Change ref after upgrade contract

### DIFF
--- a/std-reference-proxy/src/main/java/com/iconloop/score/oracle/StdReferenceProxy.java
+++ b/std-reference-proxy/src/main/java/com/iconloop/score/oracle/StdReferenceProxy.java
@@ -16,8 +16,8 @@ public class StdReferenceProxy {
     public StdReferenceProxy(Address _ref) {
         if (this.owner.get() == null) {
             this.owner.set(Context.getCaller());
-            this.ref.set(_ref);
         }
+        this.ref.set(_ref);
     }
 
     @External()


### PR DESCRIPTION
When we deploy new proxy contract, we need to change the base contract in one transaction to make upgrade smoothly (or set the same ref if don't want to change base)